### PR TITLE
Add .NET Core 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/2.1/stretch-slim/Dockerfile
+++ b/2.1/stretch-slim/Dockerfile
@@ -1,0 +1,8 @@
+
+FROM microsoft/dotnet:2.1.0-aspnetcore-runtime-stretch-slim
+# Install VSDBG for local run only.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    unzip \
+    && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds .net core 2.1 docker file, built on Debian 9 Stretch 